### PR TITLE
Fix JSON tests

### DIFF
--- a/tests/response/setContentDownload.phpt
+++ b/tests/response/setContentDownload.phpt
@@ -7,8 +7,6 @@ ServerResponse::setContentDownload
 ) {
     die('skip ');
 } ?>
---EXTENSIONS--
-json
 --FILE--
 <?php
 $response = new ServerResponse();

--- a/tests/response/setContentDownload_notResource.phpt
+++ b/tests/response/setContentDownload_notResource.phpt
@@ -7,8 +7,6 @@ ServerResponse::setContentResource (not resource)
 ) {
     die('skip ');
 } ?>
---EXTENSIONS--
-json
 --FILE--
 <?php
 $response = new ServerResponse();

--- a/tests/response/setContentJson.phpt
+++ b/tests/response/setContentJson.phpt
@@ -7,8 +7,6 @@ ServerResponse::setContentJson
 ) {
     die('skip ');
 } ?>
---EXTENSIONS--
-json
 --FILE--
 <?php
 $response = new ServerResponse();

--- a/tests/response/setContentJson_failed.phpt
+++ b/tests/response/setContentJson_failed.phpt
@@ -7,8 +7,6 @@ ServerResponse::setContentJson (failed)
 ) {
     die('skip ');
 } ?>
---EXTENSIONS--
-json
 --FILE--
 <?php
 $response = new ServerResponse();


### PR DESCRIPTION
json is on Linux and on Windows a static extension, There is no need to load it in the *.phpt files. Moreover, the Windows tests choke on it and generate a zero-byte output.