### PR TITLE
fix return type consistency in php 7.0/7.1/7.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -114,6 +114,7 @@ Added:
                     <file role="test" name="parseContentType.phpt" />
                     <file role="test" name="parseDigestAuth.phpt" />
                     <file role="test" name="post.phpt" />
+                    <file role="test" name="reflection.phpt" />
                     <file role="test" name="superglobals-are-copied.phpt" />
                     <file role="test" name="uploads-complex.phpt" />
                     <file role="test" name="uploads-real.phpt" />

--- a/php_request.h
+++ b/php_request.h
@@ -19,7 +19,7 @@ extern zend_module_entry request_module_entry;
            ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, NULL, allow_null)
 
 #define REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, return_reference, required_num_args,            classname, allow_null) \
-          ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, IS_OBJECT, classname, allow_null)
+          ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, IS_OBJECT, #classname, allow_null)
 
 #endif
 

--- a/serverrequest.c
+++ b/serverrequest.c
@@ -67,28 +67,28 @@ REQUEST_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(ServerRequest_parseDigestAuth_args, 0
     ZEND_ARG_TYPE_INFO(0, header, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withInput_args, 0, 1, "ServerRequest", 0)
+REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withInput_args, 0, 1, ServerRequest, 0)
     ZEND_ARG_INFO(0, input)
 ZEND_END_ARG_INFO()
 
-REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withParam_args, 0, 2, "ServerRequest", 0)
+REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withParam_args, 0, 2, ServerRequest, 0)
     ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
     ZEND_ARG_INFO(0, val)
 ZEND_END_ARG_INFO()
 
-REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withParams_args, 0, 1, "ServerRequest", 0)
+REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withParams_args, 0, 1, ServerRequest, 0)
     ZEND_ARG_ARRAY_INFO(0, params, 0)
 ZEND_END_ARG_INFO()
 
-REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withoutParam_args, 0, 1, "ServerRequest", 0)
+REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withoutParam_args, 0, 1, ServerRequest, 0)
     ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withoutParams_args, 0, 1, "ServerRequest", 0)
+REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withoutParams_args, 0, 1, ServerRequest, 0)
     ZEND_ARG_ARRAY_INFO(0, keys, 1)
 ZEND_END_ARG_INFO()
 
-REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withUrl_args, 0, 1, "ServerRequest", 0)
+REQUEST_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(ServerRequest_withUrl_args, 0, 1, ServerRequest, 0)
     ZEND_ARG_ARRAY_INFO(0, url, 0)
 ZEND_END_ARG_INFO()
 /* }}} Argument Info */

--- a/tests/request/reflection.phpt
+++ b/tests/request/reflection.phpt
@@ -1,0 +1,26 @@
+--TEST--
+ServerRequest return type reflection
+--SKIPIF--
+<?php if (
+    ! extension_loaded('request')
+    && ! getenv('TEST_USERLAND_REQUEST')
+) {
+    die('skip ');
+} ?>
+--FILE--
+<?php
+foreach(['parseAccept', 'withInput', 'withParam', 'withParams', 'withoutParam', 'withoutParams', 'withUrl'] as $method) {
+  $r = new ReflectionMethod("ServerRequest", $method);
+  var_dump((string)$r->getReturnType());
+}
+?>
+Done
+--EXPECTF--
+string(5) "array"
+string(13) "ServerRequest"
+string(13) "ServerRequest"
+string(13) "ServerRequest"
+string(13) "ServerRequest"
+string(13) "ServerRequest"
+string(13) "ServerRequest"
+Done

--- a/tests/request/reflection.phpt
+++ b/tests/request/reflection.phpt
@@ -3,7 +3,6 @@ ServerRequest return type reflection
 --SKIPIF--
 <?php if (
     ! extension_loaded('request')
-    && ! getenv('TEST_USERLAND_REQUEST')
 ) {
     die('skip ');
 } ?>

--- a/tests/request/reflection.phpt
+++ b/tests/request/reflection.phpt
@@ -15,8 +15,7 @@ foreach(['withInput', 'withParam', 'withParams', 'withoutParam', 'withoutParams'
 }
 ?>
 Done
---EXPECTF--
-string(5) "array"
+--EXPECT--
 string(13) "ServerRequest"
 string(13) "ServerRequest"
 string(13) "ServerRequest"

--- a/tests/request/reflection.phpt
+++ b/tests/request/reflection.phpt
@@ -9,7 +9,7 @@ ServerRequest return type reflection
 } ?>
 --FILE--
 <?php
-foreach(['parseAccept', 'withInput', 'withParam', 'withParams', 'withoutParam', 'withoutParams', 'withUrl'] as $method) {
+foreach(['withInput', 'withParam', 'withParams', 'withoutParam', 'withoutParams', 'withUrl'] as $method) {
   $r = new ReflectionMethod("ServerRequest", $method);
   var_dump((string)$r->getReturnType());
 }


### PR DESCRIPTION
Working a bit more in compatibility of return type across version, as 7.2 expect class name without quote, this should be made consistent in all versions.
