### PR TITLE
Fix more segfaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,12 @@ branches:
 
 sudo: required
 
+before_script:
+  - ulimit -c unlimited -S
+
 before_install:
   - travis_retry sudo apt-get update -y
-  - travis_retry sudo apt-get install -y lcov valgrind
+  - travis_retry sudo apt-get install -y lcov valgrind gdb
   - travis_retry gem install coveralls-lcov
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,16 @@ language: php
 php:
   - 7.3
   - 7.4
-  - nightly
+  - master
 
 branches:
   only:
     - 2.x
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 'master'
 
 sudo: required
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: '{branch}.{build}'
 branches:
   only:
   - 2.x
+  - appveyor
 
 platform:
 - x86
@@ -15,12 +16,12 @@ environment:
 
   matrix:
     - PHP_VER: 7.3
-      PHP_FULL_VER: 7.3.14
+      PHP_FULL_VER: 7.3.13
       VC_VER: vc15
       PHP_BUILD_TYPE: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     - PHP_VER: 7.4
-      PHP_FULL_VER: 7.4.2
+      PHP_FULL_VER: 7.4.1
       VC_VER: vc15
       PHP_BUILD_TYPE: nts-Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015

--- a/php_request.c
+++ b/php_request.c
@@ -1565,18 +1565,6 @@ static void server_response_set_cookie(INTERNAL_FUNCTION_PARAMETERS, zend_bool u
     // Cleanup
     zval_ptr_dtor(&member);
 
-    if (expires_or_options && Z_TYPE_P(expires_or_options) == IS_ARRAY) {
-        if (path) {
-            zend_string_release(path);
-        }
-        if (domain) {
-            zend_string_release(domain);
-        }
-        if (samesite) {
-            zend_string_release(samesite);
-        }
-    }
-
     RETURN_TRUE;
 }
 

--- a/php_request.c
+++ b/php_request.c
@@ -890,7 +890,7 @@ PHP_METHOD(ServerRequest, __construct)
     zval *_this_zval;
     zval *init;
     zval *globals = NULL;
-    zval *content;
+    zval *content = NULL;
     zval *server;
     zval *files;
     zval rv = {0};

--- a/php_request.c
+++ b/php_request.c
@@ -653,7 +653,7 @@ static inline void server_request_init_array_prop(
     const char *obj_key,
     size_t obj_key_length
 ) {
-    zval *tmp;
+    zval tmp = {0};
     array_init(&tmp);
     zend_update_property(ServerRequest_ce_ptr, obj, obj_key, obj_key_length, &tmp);
 }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -56,5 +56,10 @@ after_failure)
         printf "\n";
         echo "-- END";
     done
+    # get backtrace for coredumps
+    COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1)
+    if [[ -f "$COREFILE" ]]; then
+      gdb -c "$COREFILE" $(phpenv which php) -ex "thread apply all bt" -ex "set pagination 0" -batch
+    fi
     ;;
 esac

--- a/tests/response/setCookie-bad.phpt
+++ b/tests/response/setCookie-bad.phpt
@@ -11,7 +11,7 @@ try {
 }
 --EXPECTF--
 
-Warning: ServerResponse::setCookie(): Unrecognized key 'nosuchoption' found in the options array in %s/setCookie-bad.php on line %d
+Warning: ServerResponse::setCookie(): Unrecognized key 'nosuchoption' found in the options array in %ssetCookie-bad.php on line %d
 
-Warning: ServerResponse::setCookie(): No valid options were found in the given array in %s/setCookie-bad.php on line %d
+Warning: ServerResponse::setCookie(): No valid options were found in the given array in %ssetCookie-bad.php on line %d
 Cannot pass arguments after the options array

--- a/tests/sender/send-extended.phpt
+++ b/tests/sender/send-extended.phpt
@@ -13,7 +13,7 @@ $ext->setHeader('foo', 'bar');
 $ext->setCookie('baz', 'dib');
 $ext->setContent('content');
 (new ServerResponseSender())->send($ext);
-echo PHP_EOL;
+echo "\n";
 var_dump(headers_list());
 --EXPECT--
 content


### PR DESCRIPTION
* Print coredump in after_failure
* Fix segfault in ServerRequest::__construct caused when accessing uninitialized memory of second argument `content`
* Fix double-free in setCookie - Removing the block should be safe because the strings are all
added to the return zval

I looked into re-enabling valgrind but apparently TravisCI's PHP is built "without valgrind support" and will always trigger a bunch of false positives, sadly.